### PR TITLE
Added corrupt file status checker and feature for summation of specified excel sheet column

### DIFF
--- a/excel_api/excel_handler.py
+++ b/excel_api/excel_handler.py
@@ -1,0 +1,19 @@
+import xlrd
+from xlrd import open_workbook, XLRDError
+import pandas as pd
+
+
+def test_file(excel_file):
+    try:
+        xlrd.open_workbook(excel_file)
+
+    except XLRDError as e:
+        return e
+    else:
+        return "File is clean"
+    
+    
+def column_sum(file_path, sheet, column_name):
+    excel_data = pd.read_excel(file_path, sheet)
+    excel_data.fillna(value="No Data Found", inplace=True)
+    return excel_data[column_name].sum()

--- a/excel_api/urls.py
+++ b/excel_api/urls.py
@@ -1,9 +1,12 @@
 from django.urls import path
 
-from .views import parserview, FilesList, FilesAdd
+from .views import parserview, FilesList, FilesAdd, check_file
+
 
 urlpatterns = [
     path('add/', FilesAdd.as_view()),
     path('parse/', parserview),
     path('getall/', FilesList.as_view()),
+    path('checkfile/', check_file),
 
+]

--- a/excel_api/urls.py
+++ b/excel_api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import parserview, FilesList, FilesAdd, check_file
+from .views import parserview, FilesList, FilesAdd, check_file, column_sum
 
 
 urlpatterns = [
@@ -8,5 +8,6 @@ urlpatterns = [
     path('parse/', parserview),
     path('getall/', FilesList.as_view()),
     path('checkfile/', check_file),
+    path('column_sum/', column_sum),
 
 ]

--- a/excel_api/views.py
+++ b/excel_api/views.py
@@ -15,6 +15,7 @@ from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.parsers import JSONParser
 from .excel_handler import test_file
+from .excel_handler import column_sum
 
 
 # Create your views here.
@@ -78,7 +79,7 @@ def column_sum(request):
         sheet_name = data['sheet']
         column_name = data['column']
         
-        sum_result = column_sum(path_value, sheet_name, column_names)
+        sum_result = column_sum(path_value, sheet_name, column_name)
         return JsonResponse(sum_result, status=201, safe=False)
 
 

--- a/excel_api/views.py
+++ b/excel_api/views.py
@@ -11,6 +11,10 @@ from excel_api.models import Files
 from excel_api.serializers import FileSerializer
 from rest_framework import generics
 from excel_api.excel_parser import get_file_name, start_timer
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.parsers import JSONParser
+from .excel_handler import test_file
 
 
 # Create your views here.
@@ -49,3 +53,18 @@ def parserview(request):
     json_parsed = {'data': data, 'process_time': total_time}
 
     return Response(json_parsed)
+
+
+
+@csrf_exempt
+def check_file(request):
+    if request.method == 'POST':
+        data = JSONParser().parse(request)
+        path_value = data['path']
+        test_result = test_file(path_value)
+        return JsonResponse(test_result, status=201, safe=False)
+
+
+    else:
+        message = "Access Denied, Use post method"
+        return JsonResponse(message, status=400, safe=False)

--- a/excel_api/views.py
+++ b/excel_api/views.py
@@ -68,3 +68,20 @@ def check_file(request):
     else:
         message = "Access Denied, Use post method"
         return JsonResponse(message, status=400, safe=False)
+    
+    
+@csrf_exempt
+def column_sum(request):
+    if request.method == 'POST':
+        data = JSONParser().parse(request)
+        path_value = data['path']
+        sheet_name = data['sheet']
+        column_name = data['column']
+        
+        sum_result = column_sum(path_value, sheet_name, column_names)
+        return JsonResponse(sum_result, status=201, safe=False)
+
+
+    else:
+        message = "Access Denied, Use post method"
+        return JsonResponse(message, status=400, safe=False)


### PR DESCRIPTION
I added a feature that will enable decipher if an excel sheet is corrupt, and also that which will calculate and output the sum of any specified column.

both make use of post methods only

JSON call for file status check must be in this form:
{
"path" : "C:\\Users\\hp\\Desktop\\ml1\\Book1.xlsx"
}

JSON call for sum of a specified column must be in this form:
{
"path" : "C:\\Users\\hp\\Desktop\\ml1\\Book1.xlsx",
"sheet" : "sheet1",
"column" : "salary"
}

